### PR TITLE
Sealgo行程篩選完成

### DIFF
--- a/src/main/java/chilltrip/trip/controller/TripController.java
+++ b/src/main/java/chilltrip/trip/controller/TripController.java
@@ -64,24 +64,80 @@ public class TripController {
 			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
 		}
 	}
-	
+
 	// 首頁熱門文章 API
 	@GetMapping("/popular")
 	public ResponseEntity<Map<String, Object>> getPopularTrips() {
-	    try {
-	        List<Map<String, Object>> popularTrips = tripSvc.getPopularTrips();
+		try {
+			List<Map<String, Object>> popularTrips = tripSvc.getPopularTrips();
 
-	        Map<String, Object> response = new HashMap<>();
-	        response.put("content", popularTrips);
-	        
-	        return ResponseEntity.ok(response);
-	    } catch (Exception e) {
-	        e.printStackTrace(); // 在控制台打印詳細錯誤
-	        Map<String, Object> errorResponse = new HashMap<>();
-	        errorResponse.put("error", e.getClass().getName());
-	        errorResponse.put("message", e.getMessage());
-	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
-	    }
+			Map<String, Object> response = new HashMap<>();
+			response.put("content", popularTrips);
+
+			return ResponseEntity.ok(response);
+		} catch (Exception e) {
+			e.printStackTrace(); // 在控制台打印詳細錯誤
+			Map<String, Object> errorResponse = new HashMap<>();
+			errorResponse.put("error", e.getClass().getName());
+			errorResponse.put("message", e.getMessage());
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+		}
+	}
+
+	// 根據活動查詢文章（多表查詢且要分頁）
+	@GetMapping("/activityfilter")
+	public ResponseEntity<Map<String, Object>> getTripsByEvent(@RequestParam String eventContent,
+			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "12") int size) {
+
+		try {
+			// 建立分頁請求
+			Pageable pageable = PageRequest.of(page, size);
+			// 調用 Service 層的地區查詢方法
+			Page<Map<String, Object>> pageResult = tripSvc.getTripsByActivity(eventContent, pageable);
+
+			// 構建回應
+			Map<String, Object> response = new HashMap<>();
+			response.put("content", pageResult.getContent());
+			response.put("totalPages", pageResult.getTotalPages());
+			response.put("totalElements", pageResult.getTotalElements());
+			response.put("currentPage", page);
+
+			return ResponseEntity.ok(response);
+		} catch (Exception e) {
+			e.printStackTrace();
+			Map<String, Object> errorResponse = new HashMap<>();
+			errorResponse.put("error", e.getClass().getName());
+			errorResponse.put("message", e.getMessage());
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+		}
+	}
+
+	// 根據地區查詢文章（多表查詢且要分頁）
+	@GetMapping("/areafilter")
+	public ResponseEntity<Map<String, Object>> getTripsByArea(@RequestParam String regionContent,
+			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "12") int size) {
+
+		try {
+			// 建立分頁請求
+			Pageable pageable = PageRequest.of(page, size);
+			// 調用 Service 層的地區查詢方法
+			Page<Map<String, Object>> pageResult = tripSvc.getTripsByArea(regionContent, pageable);
+
+			// 構建回應
+			Map<String, Object> response = new HashMap<>();
+			response.put("content", pageResult.getContent());
+			response.put("totalPages", pageResult.getTotalPages());
+			response.put("totalElements", pageResult.getTotalElements());
+			response.put("currentPage", page);
+
+			return ResponseEntity.ok(response);
+		} catch (Exception e) {
+			e.printStackTrace();
+			Map<String, Object> errorResponse = new HashMap<>();
+			errorResponse.put("error", e.getClass().getName());
+			errorResponse.put("message", e.getMessage());
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+		}
 	}
 
 }

--- a/src/main/java/chilltrip/trip/model/TripService.java
+++ b/src/main/java/chilltrip/trip/model/TripService.java
@@ -187,8 +187,124 @@ public class TripService {
 
 	        result.add(tripMap);
 	    }
-
 	    return result;
+	}
+	
+	
+	
+	@Transactional(readOnly = true)
+	public Page<Map<String, Object>> getTripsByArea(String regionContent, Pageable pageable) {
+	    // 使用地區條件查詢
+	    Page<Object[]> tripsPage = tripRepository.findByRegionContent(regionContent, pageable);
+
+	    return tripsPage.map(tripArray -> {
+	        // 獲取並處理標籤
+	        List<Object[]> tagArrays = tripRepository.findTripTags((Integer) tripArray[0]);
+	        List<String> tags = new ArrayList<>();
+
+	        for (Object[] tagArray : tagArrays) {
+	            String regionTag = (String) tagArray[0];
+	            String eventTag = (String) tagArray[1];
+
+	            // 判斷標籤是否為空
+	            if (regionTag != null && !regionTag.trim().isEmpty()) {
+	                tags.add(regionTag);
+	            }
+	            if (eventTag != null && !eventTag.trim().isEmpty()) {
+	                tags.add(eventTag);
+	            }
+	        }
+
+	        // 直接建立 Map
+	        Map<String, Object> tripMap = new HashMap<>();
+	        tripMap.put("id", tripArray[0]);
+
+	        // 標題判斷
+	        String title = (tripArray[1] == null || ((String)tripArray[1]).trim().isEmpty())
+	            ? "未命名行程"
+	            : (String)tripArray[1];
+	        tripMap.put("title", title);
+
+	        // 描述判斷
+	        String description = (tripArray[2] == null || ((String)tripArray[2]).trim().isEmpty())
+	            ? "沒有行程簡介"
+	            : (String)tripArray[2];
+	        tripMap.put("description", description);
+
+	        tripMap.put("views", tripArray[3]);
+	        tripMap.put("likes", tripArray[4]);
+	        tripMap.put("rating", tripArray[5]);
+
+	        // 作者判斷
+	        String author = (tripArray[6] == null || ((String)tripArray[6]).trim().isEmpty())
+	            ? "未知作者"
+	            : (String)tripArray[6];
+	        tripMap.put("author", author);
+
+	        tripMap.put("image", tripArray[7]);
+	        tripMap.put("tags", tags);
+
+	        System.out.println(tripMap);
+	        return tripMap;
+	    });
+	}
+	
+	
+	@Transactional(readOnly = true)
+	public Page<Map<String, Object>> getTripsByActivity(String eventContent, Pageable pageable) {
+	   // 使用活動類型條件查詢 
+	   Page<Object[]> tripsPage = tripRepository.findByEventContent(eventContent, pageable);
+
+	   return tripsPage.map(tripArray -> {
+	       // 獲取並處理標籤
+	       List<Object[]> tagArrays = tripRepository.findTripTags((Integer) tripArray[0]);
+	       List<String> tags = new ArrayList<>();
+
+	       for (Object[] tagArray : tagArrays) {
+	           String regionTag = (String) tagArray[0];
+	           String eventTag = (String) tagArray[1];
+
+	           // 判斷標籤是否為空
+	           if (regionTag != null && !regionTag.trim().isEmpty()) {
+	               tags.add(regionTag);
+	           }
+	           if (eventTag != null && !eventTag.trim().isEmpty()) {
+	               tags.add(eventTag);
+	           }
+	       }
+
+	       // 直接建立 Map
+	       Map<String, Object> tripMap = new HashMap<>();
+	       tripMap.put("id", tripArray[0]);
+
+	       // 標題判斷
+	       String title = (tripArray[1] == null || ((String)tripArray[1]).trim().isEmpty())
+	           ? "未命名行程"
+	           : (String)tripArray[1];
+	       tripMap.put("title", title);
+
+	       // 描述判斷
+	       String description = (tripArray[2] == null || ((String)tripArray[2]).trim().isEmpty())
+	           ? "沒有行程簡介"
+	           : (String)tripArray[2];
+	       tripMap.put("description", description);
+
+	       tripMap.put("views", tripArray[3]);
+	       tripMap.put("likes", tripArray[4]);
+	       tripMap.put("rating", tripArray[5]);
+
+	       // 作者判斷
+	       String author = (tripArray[6] == null || ((String)tripArray[6]).trim().isEmpty())
+	           ? "未知作者"
+	           : (String)tripArray[6];
+	       tripMap.put("author", author);
+
+	       tripMap.put("image", tripArray[7]);
+	       tripMap.put("tags", tags);
+
+	       System.out.println(tripMap);
+	       return tripMap;
+	   });
 	}
 	
 

--- a/src/main/java/chilltrip/tripactype/controller/TripactypeController.java
+++ b/src/main/java/chilltrip/tripactype/controller/TripactypeController.java
@@ -85,6 +85,7 @@ public class TripactypeController{
 	// 查詢指定行程活動類型的所有行程
     @GetMapping("/trips")
     public ResponseEntity<List<Map<String, Object>>> getTripsByTripActype(@RequestParam String eventType) {
+    	System.out.println(eventType);
         List<Map<String, Object>> tripDataList = tripactypeSvc.findTripsByEventType(eventType);
         if (tripDataList == null || tripDataList.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);

--- a/src/main/resources/static/js/maphsiuchi.js
+++ b/src/main/resources/static/js/maphsiuchi.js
@@ -85,7 +85,7 @@ function handleSearchResults(results, status) {
 
     // 在地圖上添加標記
     formattedResults.forEach(place => {
-      const marker = new google.maps.Marker({
+      const marker = new google.maps.marker.AdvancedMarkerElement({
         map,
         position: place.location,
         title: place.name
@@ -108,6 +108,7 @@ function clearMarkers() {
 
 // 渲染景點列表
 function renderPlaceList(places) {
+  console.log(place);
   const placeList = $(".place-list");
   placeList.empty();
 

--- a/src/main/resources/templates/frontend/sealgo.html
+++ b/src/main/resources/templates/frontend/sealgo.html
@@ -755,52 +755,67 @@
       .error-message {
         color: #dc3545;
       }
+
+      .no-results {
+        text-align: center;
+        padding: 40px;
+        font-size: 1.2em;
+        color: #666;
+        background: #f9f9f9;
+        border-radius: 8px;
+        margin: 20px 0;
+      }
     </style>
   </head>
 
   <body>
     <!------網站header------>
-      <header>
-        <nav class="top-nav">
-          <div class="nav-left">
-            <a href="#" class="nav-item nav-link" id="nav-go">Go！行程</a>
-            <a href="#" class="nav-item nav-link" id="nav-product">購！票券</a>
-            <a href="#" class="nav-item nav-link" id="nav-profile">個人主頁</a>
-            <a href="#" class="nav-item nav-link" id="nav-guide">使用指南</a>
-          </div>
-          <div class="nav-center">
-            <a href="#" id="z-index">
-              <a href="/TIA104G2-SpringBoot/" id="z-index"> <img th:src="@{/img/logo_black.png}"
-						alt="Chill Trip" style="width: 150px; height: auto" />
-					</a>
+    <header>
+      <nav class="top-nav">
+        <div class="nav-left">
+          <a href="#" class="nav-item nav-link" id="nav-go">Go！行程</a>
+          <a href="#" class="nav-item nav-link" id="nav-product">購！票券</a>
+          <a href="#" class="nav-item nav-link" id="nav-profile">個人主頁</a>
+          <a href="#" class="nav-item nav-link" id="nav-guide">使用指南</a>
+        </div>
+        <div class="nav-center">
+          <a href="#" id="z-index">
+            <a href="/TIA104G2-SpringBoot/" id="z-index">
+              <img
+                th:src="@{/img/logo_black.png}"
+                alt="Chill Trip"
+                style="width: 150px; height: auto"
+              />
             </a>
-          </div>
-          <div class="nav-right">
-          <a href="/TIA104G2-SpringBoot/login" class="nav-item nav-link  active" id="nav-login"
-						style="color: #FF6600;">登入/註冊</a>
-            <div class="nav-item dropdown">
-              <a
-                href="#"
-                class="nav-link dropdown-toggle"
-                data-toggle="dropdown"
-                style="color: #212529"
-                >會員中心</a
-              >
-              <div class="dropdown-menu rounded-0 m-0">
-                <a href="#" class="dropdown-item" id="nav-basic-info"
-                  >基本資料</a
-                >
-                <a href="#" class="dropdown-item" id="nav-coupons"
-                  >我的折價券</a
-                >
-                <a href="#" class="dropdown-item" id="nav-orders">歷史訂單</a>
-              </div>
+          </a>
+        </div>
+        <div class="nav-right">
+          <a
+            href="/TIA104G2-SpringBoot/login"
+            class="nav-item nav-link active"
+            id="nav-login"
+            style="color: #ff6600"
+            >登入/註冊</a
+          >
+          <div class="nav-item dropdown">
+            <a
+              href="#"
+              class="nav-link dropdown-toggle"
+              data-toggle="dropdown"
+              style="color: #212529"
+              >會員中心</a
+            >
+            <div class="dropdown-menu rounded-0 m-0">
+              <a href="#" class="dropdown-item" id="nav-basic-info">基本資料</a>
+              <a href="#" class="dropdown-item" id="nav-coupons">我的折價券</a>
+              <a href="#" class="dropdown-item" id="nav-orders">歷史訂單</a>
             </div>
-            <a href="#" class="nav-item nav-link" id="nav-support">客服中心</a>
-            <a href="#" class="nav-item nav-link" id="nav-cart">購物車</a>
           </div>
-        </nav>
-      </header>
+          <a href="#" class="nav-item nav-link" id="nav-support">客服中心</a>
+          <a href="#" class="nav-item nav-link" id="nav-cart">購物車</a>
+        </div>
+      </nav>
+    </header>
 
     <div aria-label="breadcrumb">
       <ul class="breadcrumb" id="breadcrumb-nav">
@@ -1000,10 +1015,14 @@
     <!-- Template Javascript -->
     <script th:src="@{/js/main.js}"></script>
 
+    <!-- Google Map -->
+    <script th:src="@{/js/maphsiuchi.js}"></script>
+
     <!-- 導航欄nav的href載入器 -->
+    <script th:src="@{/js/navigation.js}"></script>
+
     <script>
       document.addEventListener("DOMContentLoaded", function () {
-        
         const breadcrumbNav = document.getElementById("breadcrumb-nav");
         // 定義麵包屑導航的項目
         const breadcrumbItems = [
@@ -1267,16 +1286,106 @@
         }
 
         // 篩選器和搜尋功能 (活動類型、地區選擇、關鍵字搜尋)
+        // 活動類型篩選
         activitySelect.on("change", function () {
-          currentPage = 0; // 重置頁碼
-          loadArticles(currentPage);
+          const selectedActivity = $(this).val();
+          currentPage = 0;
+
+          if (selectedActivity) {
+            $.ajax({
+              url: `${contextPath}/trip/activityfilter`, // 修改為新的後端路徑
+              type: "GET",
+              data: {
+                eventContent: selectedActivity, // 修改參數名稱與後端對應
+                page: currentPage,
+                size: pageSize,
+              },
+              success: function (response) {
+                if (response && response.content) {
+                  // 由於後端返回分頁格式，檢查 response.content
+                  currentArticles = transformTripsToArticles(response.content);
+                  renderArticles(currentArticles);
+                  renderPagination({
+                    content: response.content,
+                    totalPages: response.totalPages,
+                    totalElements: response.totalElements,
+                    number: response.currentPage,
+                  });
+                } else {
+                  articlesGrid.html(
+                    '<p class="no-results">目前沒有這個活動類型的行程</p>'
+                  );
+                  $(".pagination").hide();
+                }
+              },
+              error: function (xhr) {
+                if (xhr.status === 404) {
+                  // 404 錯誤時顯示友善訊息
+                  articlesGrid.html(
+                    '<p class="no-results">目前沒有這個活動類型的行程</p>'
+                  );
+                  $(".pagination").hide();
+                } else {
+                  showErrorMessage("篩選活動類型失敗，請稍後再試");
+                }
+              },
+            });
+          } else {
+            loadArticles(currentPage);
+          }
         });
 
+        // 地區篩選
         regionSelect.on("change", function () {
-          currentPage = 0; // 重置頁碼
-          loadArticles(currentPage);
+          const selectedRegion = $(this).val();
+          currentPage = 0;
+
+          if (selectedRegion) {
+            $.ajax({
+              url: `${contextPath}/trip/areafilter`, // 修改為新的後端路徑
+              type: "GET",
+              data: {
+                regionContent: selectedRegion, // 確保參數名稱與後端一致
+                page: currentPage,
+                size: pageSize,
+              },
+              success: function (response) {
+                if (response && response.content) {
+                  // 後端返回分頁格式
+                  currentArticles = transformTripsToArticles(response.content);
+                  renderArticles(currentArticles);
+                  renderPagination({
+                    content: response.content,
+                    totalPages: response.totalPages,
+                    totalElements: response.totalElements,
+                    number: response.currentPage,
+                  });
+                } else {
+                  articlesGrid.html(
+                    '<p class="no-results">目前沒有這個地區的行程</p>'
+                  );
+                  $(".pagination").hide();
+                }
+              },
+              error: function (xhr) {
+                if (xhr.status === 404) {
+                  // 404 錯誤時顯示友善提示
+                  articlesGrid.html(
+                    '<p class="no-results">目前沒有這個地區的行程</p>'
+                  );
+                  $(".pagination").hide();
+                } else {
+                  console.error("篩選錯誤:", xhr);
+                  showErrorMessage("篩選地區失敗，請稍後再試");
+                }
+              },
+            });
+          } else {
+            loadArticles(currentPage);
+          }
         });
 
+        //輸入框查詢
         searchInput.on("input", function () {
           currentPage = 0; // 重置頁碼
           loadArticles(currentPage);


### PR DESCRIPTION
Sealgo地區、活動的分頁查詢修改、移植過去了
搜索部分剩下搜索筐要能同時搜尋標題行稱、景點名稱、作者名稱了
（並回傳整合了四張表的卡片資訊渲染畫面）